### PR TITLE
Add goby_gpsd to debian package build

### DIFF
--- a/control
+++ b/control
@@ -29,6 +29,7 @@ Build-Depends: cdbs (>= 0.4.130~),
                libmoos10-dev (>= 10.0.2~),
                libais-dev (>= 0.17~),
                libmavlink-dev (>= 1.0.12~),
+               libgps-dev (>= 3.15~),
                llvm-dev (>=1:4~) [amd64] | llvm-4.0-dev [amd64] | llvm-7-dev [amd64],
                libclang-dev (>=1:4~) [amd64] | libclang-4.0-dev [amd64] | libclang-7-dev [amd64],
                libyaml-cpp-dev (>=0.5.2-3) [amd64]

--- a/goby3-apps.install
+++ b/goby3-apps.install
@@ -9,3 +9,4 @@ usr/bin/goby_coroner
 usr/bin/goby_mavlink_gateway
 usr/bin/goby_frontseat_interface*
 usr/bin/goby_serial_mux
+usr/bin/goby_gpsd


### PR DESCRIPTION
Merge *before* https://github.com/GobySoft/goby3/pull/180 to ensure `goby_gpsd` shows up in the continuous package.